### PR TITLE
suppress sha512 warning, fix gradle uses clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ You must add a step in your build.gradle to publish the artifacts.
                }
              }
 ```
+
+Additionally, if you get this warning:
+
+    Cannot upload checksum for module-maven-metadata.xml because the remote repository doesn't support SHA-512. This will not fail the build.
+
+You can suppress it by specifying the following system property when running your gradle command:
+
+    -Dorg.gradle.internal.publish.checksums.insecure=true
+
+
+
 # maven notes  
 If going to dev-sherwin-release-apps, you must add this parent block in pom.xml
 ```

--- a/workflow-templates/gradlejarpublish-artifactory.yml
+++ b/workflow-templates/gradlejarpublish-artifactory.yml
@@ -23,9 +23,9 @@ jobs:
         run: chmod +x gradlew
     
       - name: Build gradle jar and deploy to artifactory
-        uses: eskatos/gradle-command-action@v1
+        uses: gradle/gradle-build-action@v2.1.4
         with:
-          arguments: publish
+          arguments: -Dorg.gradle.internal.publish.checksums.insecure=true publish
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}


### PR DESCRIPTION
The `eskatos` gradle step wasn't working, it appears to have been moved to `gradle`
Suppress sha512 not supported warning.